### PR TITLE
feat: MLS client — port mls.sh to Go

### DIFF
--- a/internal/mls/client.go
+++ b/internal/mls/client.go
@@ -1,0 +1,221 @@
+// Package mls fetches property data from realtor.com and RapidAPI.
+package mls
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	defaultSuggestURL  = "https://parser-external.geo.moveaws.com/suggest"
+	defaultHulkURL     = "https://www.realtor.com/api/v1/hulk_main_srp?client_id=rdc-x&schema=vesta"
+	defaultRapidAPIURL = "https://us-real-estate-listings.p.rapidapi.com/v2/property"
+	userAgent          = "Mozilla/5.0"
+)
+
+// Result holds the data returned from a property lookup.
+type Result struct {
+	MprID      string          `json:"mpr_id"`
+	RealtorURL string          `json:"realtor_url"`
+	RawJSON    json.RawMessage `json:"raw_json"`
+}
+
+// Client fetches property data from external APIs.
+type Client struct {
+	httpClient  *http.Client
+	rapidAPIKey string
+
+	// Overridable URLs for testing.
+	suggestURL  string
+	hulkURL     string
+	rapidAPIURL string
+}
+
+// NewClient creates an MLS client with the given RapidAPI key.
+func NewClient(rapidAPIKey string) (*Client, error) {
+	if rapidAPIKey == "" {
+		return nil, fmt.Errorf("RAPIDAPI_KEY is required")
+	}
+	return &Client{
+		httpClient:  &http.Client{},
+		rapidAPIKey: rapidAPIKey,
+		suggestURL:  defaultSuggestURL,
+		hulkURL:     defaultHulkURL,
+		rapidAPIURL: defaultRapidAPIURL,
+	}, nil
+}
+
+// Lookup fetches property data for the given address.
+// This makes API calls: 2 free (realtor.com) + 1 RapidAPI call.
+func (c *Client) Lookup(address string) (*Result, error) {
+	if address == "" {
+		return nil, fmt.Errorf("address is required")
+	}
+
+	mprID, err := c.lookupMprID(address)
+	if err != nil {
+		return nil, fmt.Errorf("geocoder lookup: %w", err)
+	}
+
+	href, err := c.lookupRealtorURL(mprID)
+	if err != nil {
+		return nil, fmt.Errorf("realtor URL lookup: %w", err)
+	}
+
+	rawJSON, err := c.fetchPropertyDetail(href)
+	if err != nil {
+		return nil, fmt.Errorf("property detail fetch: %w", err)
+	}
+
+	return &Result{
+		MprID:      mprID,
+		RealtorURL: href,
+		RawJSON:    rawJSON,
+	}, nil
+}
+
+// suggestResponse is the response from the realtor.com suggest API.
+type suggestResponse struct {
+	Autocomplete []struct {
+		MprID string `json:"mpr_id"`
+	} `json:"autocomplete"`
+}
+
+// lookupMprID resolves an address to a realtor.com property ID.
+func (c *Client) lookupMprID(address string) (string, error) {
+	params := url.Values{
+		"input":     {address},
+		"client_id": {"rdc-home"},
+		"limit":     {"1"},
+	}
+
+	req, err := http.NewRequest("GET", c.suggestURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = fmt.Errorf("%w (also failed to close body: %v)", err, closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var result suggestResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+
+	if len(result.Autocomplete) == 0 || result.Autocomplete[0].MprID == "" {
+		return "", fmt.Errorf("no property found for address: %s", address)
+	}
+
+	return result.Autocomplete[0].MprID, nil
+}
+
+// hulkRequest is the GraphQL request body for the hulk API.
+type hulkRequest struct {
+	Query string `json:"query"`
+}
+
+// hulkResponse is the response from the hulk API.
+type hulkResponse struct {
+	Data struct {
+		Home struct {
+			Href       string `json:"href"`
+			PropertyID string `json:"property_id"`
+		} `json:"home"`
+	} `json:"data"`
+}
+
+// lookupRealtorURL resolves a property ID to a realtor.com URL.
+func (c *Client) lookupRealtorURL(mprID string) (string, error) {
+	query := fmt.Sprintf(`query { home(property_id: "%s") { href property_id } }`, mprID)
+	body, err := json.Marshal(hulkRequest{Query: query})
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", c.hulkURL, strings.NewReader(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = fmt.Errorf("%w (also failed to close body: %v)", err, closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var result hulkResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Data.Home.Href == "" {
+		return "", fmt.Errorf("no realtor.com URL found for property ID: %s", mprID)
+	}
+
+	return result.Data.Home.Href, nil
+}
+
+// fetchPropertyDetail fetches full property details from RapidAPI.
+func (c *Client) fetchPropertyDetail(realtorURL string) (json.RawMessage, error) {
+	params := url.Values{
+		"property_url": {realtorURL},
+	}
+
+	req, err := http.NewRequest("GET", c.rapidAPIURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("x-rapidapi-host", "us-real-estate-listings.p.rapidapi.com")
+	req.Header.Set("x-rapidapi-key", c.rapidAPIKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = fmt.Errorf("%w (also failed to close body: %v)", err, closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("response is not valid JSON")
+	}
+
+	return json.RawMessage(raw), nil
+}

--- a/internal/mls/client_test.go
+++ b/internal/mls/client_test.go
@@ -1,0 +1,329 @@
+package mls
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{"valid key", "test-key", false},
+		{"empty key", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c == nil {
+				t.Fatal("expected client, got nil")
+			}
+		})
+	}
+}
+
+func TestLookupMprID(t *testing.T) {
+	tests := []struct {
+		name       string
+		address    string
+		response   string
+		statusCode int
+		wantMprID  string
+		wantErr    bool
+	}{
+		{
+			name:    "successful lookup",
+			address: "123 Main St",
+			response: `{
+				"autocomplete": [{"mpr_id": "M1234567890"}]
+			}`,
+			statusCode: http.StatusOK,
+			wantMprID:  "M1234567890",
+		},
+		{
+			name:       "no results",
+			address:    "Nonexistent Address",
+			response:   `{"autocomplete": []}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+		{
+			name:       "empty mpr_id",
+			address:    "Bad Address",
+			response:   `{"autocomplete": [{"mpr_id": ""}]}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			address:    "123 Main St",
+			response:   `{}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid json",
+			address:    "123 Main St",
+			response:   `not json`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("input") != tt.address {
+					t.Errorf("input = %q, want %q", r.URL.Query().Get("input"), tt.address)
+				}
+				if r.URL.Query().Get("client_id") != "rdc-home" {
+					t.Errorf("client_id = %q, want %q", r.URL.Query().Get("client_id"), "rdc-home")
+				}
+				w.WriteHeader(tt.statusCode)
+				writeResponse(t, w, tt.response)
+			}))
+			defer server.Close()
+
+			c := testClient(t, server.URL, "", "")
+
+			mprID, err := c.lookupMprID(tt.address)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if mprID != tt.wantMprID {
+				t.Errorf("mprID = %q, want %q", mprID, tt.wantMprID)
+			}
+		})
+	}
+}
+
+func TestLookupRealtorURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		mprID      string
+		response   string
+		statusCode int
+		wantURL    string
+		wantErr    bool
+	}{
+		{
+			name:  "successful lookup",
+			mprID: "M1234567890",
+			response: `{
+				"data": {"home": {"href": "/realestateandhomes-detail/123-Main-St_City_ST_12345_M12345-67890", "property_id": "M1234567890"}}
+			}`,
+			statusCode: http.StatusOK,
+			wantURL:    "/realestateandhomes-detail/123-Main-St_City_ST_12345_M12345-67890",
+		},
+		{
+			name:       "empty href",
+			mprID:      "M0000000000",
+			response:   `{"data": {"home": {"href": "", "property_id": ""}}}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			mprID:      "M1234567890",
+			response:   `{}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("method = %q, want POST", r.Method)
+				}
+				if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", ct)
+				}
+
+				var req hulkRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				writeResponse(t, w, tt.response)
+			}))
+			defer server.Close()
+
+			c := testClient(t, "", server.URL, "")
+
+			href, err := c.lookupRealtorURL(tt.mprID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if href != tt.wantURL {
+				t.Errorf("href = %q, want %q", href, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestFetchPropertyDetail(t *testing.T) {
+	tests := []struct {
+		name       string
+		realtorURL string
+		response   string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "successful fetch",
+			realtorURL: "/realestateandhomes-detail/123-Main-St",
+			response:   `{"property": {"price": 250000, "beds": 3}}`,
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "server error",
+			realtorURL: "/realestateandhomes-detail/123-Main-St",
+			response:   `{}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid json response",
+			realtorURL: "/realestateandhomes-detail/123-Main-St",
+			response:   `not json at all`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("x-rapidapi-key") != "test-key" {
+					t.Errorf("x-rapidapi-key = %q, want %q", r.Header.Get("x-rapidapi-key"), "test-key")
+				}
+				if r.Header.Get("x-rapidapi-host") != "us-real-estate-listings.p.rapidapi.com" {
+					t.Errorf("x-rapidapi-host = %q, want expected value", r.Header.Get("x-rapidapi-host"))
+				}
+				w.WriteHeader(tt.statusCode)
+				writeResponse(t, w, tt.response)
+			}))
+			defer server.Close()
+
+			c := testClient(t, "", "", server.URL)
+
+			raw, err := c.fetchPropertyDetail(tt.realtorURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !json.Valid(raw) {
+				t.Error("result is not valid JSON")
+			}
+		})
+	}
+}
+
+func TestLookupEmptyAddress(t *testing.T) {
+	c, err := NewClient("test-key")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = c.Lookup("")
+	if err == nil {
+		t.Fatal("expected error for empty address, got nil")
+	}
+}
+
+func TestLookupEndToEnd(t *testing.T) {
+	// Mock all three endpoints
+	suggestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResponse(t, w, `{"autocomplete": [{"mpr_id": "M9999999999"}]}`)
+	}))
+	defer suggestServer.Close()
+
+	hulkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResponse(t, w, `{"data": {"home": {"href": "/detail/123-Test_City_ST_00000_M99999-99999", "property_id": "M9999999999"}}}`)
+	}))
+	defer hulkServer.Close()
+
+	rapidServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResponse(t, w, `{"property": {"price": 300000, "beds": 4, "baths": 2}}`)
+	}))
+	defer rapidServer.Close()
+
+	c := testClient(t, suggestServer.URL, hulkServer.URL, rapidServer.URL)
+
+	result, err := c.Lookup("123 Test St, City, ST 00000")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+
+	if result.MprID != "M9999999999" {
+		t.Errorf("MprID = %q, want %q", result.MprID, "M9999999999")
+	}
+	if result.RealtorURL != "/detail/123-Test_City_ST_00000_M99999-99999" {
+		t.Errorf("RealtorURL = %q, want expected value", result.RealtorURL)
+	}
+	if !json.Valid(result.RawJSON) {
+		t.Error("RawJSON is not valid JSON")
+	}
+}
+
+// writeResponse writes a string to an http.ResponseWriter in tests.
+func writeResponse(t *testing.T, w http.ResponseWriter, s string) {
+	t.Helper()
+	if _, err := fmt.Fprint(w, s); err != nil {
+		t.Errorf("write response: %v", err)
+	}
+}
+
+// testClient creates a client with overridden URLs for testing.
+func testClient(t *testing.T, suggestURL, hulkURL, rapidAPIURL string) *Client {
+	t.Helper()
+	c, err := NewClient("test-key")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if suggestURL != "" {
+		c.suggestURL = suggestURL
+	}
+	if hulkURL != "" {
+		c.hulkURL = hulkURL
+	}
+	if rapidAPIURL != "" {
+		c.rapidAPIURL = rapidAPIURL
+	}
+	return c
+}


### PR DESCRIPTION
## Summary

Port the 3-step property lookup from scripts/mls.sh to Go.

## Changes

- **internal/mls/client.go** — `Client.Lookup(address)` runs the full flow:
  1. Geocoder lookup (realtor.com suggest API) → mpr_id
  2. Property ID → realtor.com URL (hulk API)
  3. RapidAPI property detail fetch → raw JSON
- **internal/mls/client_test.go** — Tests with httptest mock servers for each step + end-to-end test

## Key Details

- RAPIDAPI_KEY required via `NewClient(key)`
- Returns `Result{MprID, RealtorURL, RawJSON}` — raw JSON preserved for storage
- URLs overridable for testing (no real API calls in tests)
- Empty address and missing key return clear errors

Task: #1638