### PR TITLE
feat: property model, repository, and service

### DIFF
--- a/internal/mls/testing.go
+++ b/internal/mls/testing.go
@@ -1,0 +1,15 @@
+package mls
+
+// SetTestURLs overrides the API URLs on a client for testing.
+// This should only be used in tests.
+func SetTestURLs(c *Client, suggestURL, hulkURL, rapidAPIURL string) {
+	if suggestURL != "" {
+		c.suggestURL = suggestURL
+	}
+	if hulkURL != "" {
+		c.hulkURL = hulkURL
+	}
+	if rapidAPIURL != "" {
+		c.rapidAPIURL = rapidAPIURL
+	}
+}

--- a/internal/property/model.go
+++ b/internal/property/model.go
@@ -1,0 +1,78 @@
+// Package property provides the property domain model and data access.
+package property
+
+import (
+	"database/sql"
+	"encoding/json"
+	"time"
+)
+
+// Property represents a tracked house listing.
+type Property struct {
+	ID           int64           `json:"id"`
+	Address      string          `json:"address"`
+	MprID        string          `json:"mpr_id"`
+	RealtorURL   string          `json:"realtor_url"`
+	Price        *int64          `json:"price,omitempty"`
+	Bedrooms     *float64        `json:"bedrooms,omitempty"`
+	Bathrooms    *float64        `json:"bathrooms,omitempty"`
+	Sqft         *int64          `json:"sqft,omitempty"`
+	LotSize      *float64        `json:"lot_size,omitempty"`
+	YearBuilt    *int64          `json:"year_built,omitempty"`
+	PropertyType *string         `json:"property_type,omitempty"`
+	Status       *string         `json:"status,omitempty"`
+	Rating       *int64          `json:"rating,omitempty"`
+	RawJSON      json.RawMessage `json:"raw_json"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+// scanProperty scans a property from a database row.
+func scanProperty(row interface{ Scan(...interface{}) error }) (*Property, error) {
+	var p Property
+	var price, sqft, yearBuilt, rating sql.NullInt64
+	var bedrooms, bathrooms, lotSize sql.NullFloat64
+	var propertyType, status sql.NullString
+	var rawJSON string
+
+	err := row.Scan(
+		&p.ID, &p.Address, &p.MprID, &p.RealtorURL,
+		&price, &bedrooms, &bathrooms, &sqft, &lotSize,
+		&yearBuilt, &propertyType, &status, &rating,
+		&rawJSON, &p.CreatedAt, &p.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if price.Valid {
+		p.Price = &price.Int64
+	}
+	if bedrooms.Valid {
+		p.Bedrooms = &bedrooms.Float64
+	}
+	if bathrooms.Valid {
+		p.Bathrooms = &bathrooms.Float64
+	}
+	if sqft.Valid {
+		p.Sqft = &sqft.Int64
+	}
+	if lotSize.Valid {
+		p.LotSize = &lotSize.Float64
+	}
+	if yearBuilt.Valid {
+		p.YearBuilt = &yearBuilt.Int64
+	}
+	if propertyType.Valid {
+		p.PropertyType = &propertyType.String
+	}
+	if status.Valid {
+		p.Status = &status.String
+	}
+	if rating.Valid {
+		p.Rating = &rating.Int64
+	}
+	p.RawJSON = json.RawMessage(rawJSON)
+
+	return &p, nil
+}

--- a/internal/property/service.go
+++ b/internal/property/service.go
@@ -1,0 +1,51 @@
+package property
+
+import (
+	"fmt"
+
+	"github.com/evcraddock/house-finder/internal/mls"
+)
+
+// Service provides property business logic.
+type Service struct {
+	repo   *Repository
+	client *mls.Client
+}
+
+// NewService creates a property service.
+func NewService(repo *Repository, client *mls.Client) *Service {
+	return &Service{repo: repo, client: client}
+}
+
+// Add looks up a property by address, fetches its data, and stores it.
+// This is the only operation that hits external APIs.
+func (s *Service) Add(address string) (*Property, error) {
+	result, err := s.client.Lookup(address)
+	if err != nil {
+		return nil, fmt.Errorf("looking up property: %w", err)
+	}
+
+	fields := parseRawJSON(result.RawJSON)
+
+	p := &Property{
+		Address:      address,
+		MprID:        result.MprID,
+		RealtorURL:   result.RealtorURL,
+		Price:        fields.Price,
+		Bedrooms:     fields.Bedrooms,
+		Bathrooms:    fields.Bathrooms,
+		Sqft:         fields.Sqft,
+		LotSize:      fields.LotSize,
+		YearBuilt:    fields.YearBuilt,
+		PropertyType: fields.PropertyType,
+		Status:       fields.Status,
+		RawJSON:      result.RawJSON,
+	}
+
+	saved, err := s.repo.Insert(p)
+	if err != nil {
+		return nil, fmt.Errorf("saving property: %w", err)
+	}
+
+	return saved, nil
+}

--- a/internal/property/service_test.go
+++ b/internal/property/service_test.go
@@ -1,0 +1,139 @@
+package property
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/evcraddock/house-finder/internal/db"
+	"github.com/evcraddock/house-finder/internal/mls"
+)
+
+func TestServiceAdd(t *testing.T) {
+	suggestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResp(t, w, `{"autocomplete": [{"mpr_id": "M9999999999"}]}`)
+	}))
+	defer suggestServer.Close()
+
+	hulkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResp(t, w, `{"data": {"home": {"href": "/detail/123-Test_City_ST_00000_M99999-99999", "property_id": "M9999999999"}}}`)
+	}))
+	defer hulkServer.Close()
+
+	rapidServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResp(t, w, `{"list_price": 250000, "beds": 3, "baths": 2, "sqft": 1500, "year_built": 2010, "prop_type": "single_family", "prop_status": "active"}`)
+	}))
+	defer rapidServer.Close()
+
+	svc := testService(t, suggestServer.URL, hulkServer.URL, rapidServer.URL)
+
+	p, err := svc.Add("123 Test St, City, ST 00000")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	if p.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+	if p.Address != "123 Test St, City, ST 00000" {
+		t.Errorf("address = %q, want %q", p.Address, "123 Test St, City, ST 00000")
+	}
+	if p.MprID != "M9999999999" {
+		t.Errorf("mpr_id = %q, want %q", p.MprID, "M9999999999")
+	}
+	if p.Price == nil || *p.Price != 250000 {
+		t.Errorf("price = %v, want 250000", p.Price)
+	}
+	if !json.Valid(p.RawJSON) {
+		t.Error("raw_json is not valid JSON")
+	}
+}
+
+func TestServiceAddAPIFailure(t *testing.T) {
+	// Suggest returns no results
+	suggestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResp(t, w, `{"autocomplete": []}`)
+	}))
+	defer suggestServer.Close()
+
+	svc := testService(t, suggestServer.URL, "", "")
+
+	_, err := svc.Add("Nonexistent Address")
+	if err == nil {
+		t.Fatal("expected error when API fails")
+	}
+}
+
+func TestServiceAddNothingSavedOnFailure(t *testing.T) {
+	// Suggest works but hulk fails
+	suggestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeResp(t, w, `{"autocomplete": [{"mpr_id": "M1111111111"}]}`)
+	}))
+	defer suggestServer.Close()
+
+	hulkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer hulkServer.Close()
+
+	d, repo := testDBAndRepo(t)
+	client := testMLSClient(t, suggestServer.URL, hulkServer.URL, "")
+	svc := NewService(repo, client)
+
+	_, err := svc.Add("123 Fail St")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Verify nothing was saved
+	var count int
+	if err := d.QueryRow("SELECT COUNT(*) FROM properties").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 saved properties, got %d", count)
+	}
+}
+
+func testService(t *testing.T, suggestURL, hulkURL, rapidAPIURL string) *Service {
+	t.Helper()
+	_, repo := testDBAndRepo(t)
+	client := testMLSClient(t, suggestURL, hulkURL, rapidAPIURL)
+	return NewService(repo, client)
+}
+
+func testDBAndRepo(t *testing.T) (*sql.DB, *Repository) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := d.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+	return d, NewRepository(d)
+}
+
+func testMLSClient(t *testing.T, suggestURL, hulkURL, rapidAPIURL string) *mls.Client {
+	t.Helper()
+	client, err := mls.NewClient("test-key")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	mls.SetTestURLs(client, suggestURL, hulkURL, rapidAPIURL)
+	return client
+}
+
+func writeResp(t *testing.T, w http.ResponseWriter, s string) {
+	t.Helper()
+	if _, err := fmt.Fprint(w, s); err != nil {
+		t.Errorf("write response: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Property domain layer — model, CRUD repository, service with MLS integration.

## Changes

- **internal/property/model.go** — Property struct with nullable fields, JSON tags, scanner
- **internal/property/repository.go** — Insert, GetByID, List (min rating filter), UpdateRating, Delete + JSON field parser
- **internal/property/service.go** — Add() orchestrates: MLS lookup → parse fields → insert to DB
- **internal/property/repository_test.go** — Tests for all CRUD ops, rating validation, filtering, duplicate mpr_id, JSON parsing
- **internal/property/service_test.go** — End-to-end add, API failure, nothing-saved-on-failure
- **internal/mls/testing.go** — SetTestURLs helper

## Key Details

- All-or-nothing on add: if API or DB fails, no partial record
- Rating validation: 1-4 only, checked in Go before hitting DB
- JSON parser tries multiple field name variants (list_price/price, beds/bedrooms, etc.)
- Lot size auto-converts sqft to acres
- List filters by minimum rating (nullable — unrated properties excluded from filtered results)

Task: #1639