### PR TITLE
chore: add air for live-reload dev server

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,18 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  bin = "./tmp/hf"
+  cmd = "go build -o ./tmp/hf ./cmd/hf"
+  args_bin = ["serve", "--port", "8080"]
+  delay = 1000
+  exclude_dir = ["tmp", "vendor", ".git"]
+  exclude_regex = ["_test\\.go$"]
+  include_ext = ["go", "html", "css"]
+  kill_delay = 500
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Build
 /dist/
+/tmp/
 
 # Dependencies
 /vendor/

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-app: make build && ./hf serve --port 8080
+app: air
 


### PR DESCRIPTION
## Summary

Auto-restart the web server when code changes during development.

## Changes

- **.air.toml** — watches .go, .html, .css files, rebuilds and restarts hf serve
- **Procfile.dev** — uses `air` instead of `make build && hf serve`
- **.gitignore** — added /tmp/ (air's build directory)

## Prerequisites

```bash
go install github.com/air-verse/air@latest
```

Task: #1647