### PR TITLE
feat: API key generation and bearer token auth

### DIFF
--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -1,0 +1,142 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const apiKeyBytes = 32 // 256-bit keys
+
+// APIKey is the stored representation of an API key (no raw key).
+type APIKey struct {
+	ID         int64
+	Name       string
+	KeyPrefix  string // first 8 chars for identification
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
+}
+
+// APIKeyStore manages API keys in SQLite.
+type APIKeyStore struct {
+	db *sql.DB
+}
+
+// NewAPIKeyStore creates an API key store.
+func NewAPIKeyStore(db *sql.DB) *APIKeyStore {
+	return &APIKeyStore{db: db}
+}
+
+// Create generates a new API key with the given name.
+// Returns the raw key (shown once to user) and the stored record.
+func (s *APIKeyStore) Create(name string) (string, *APIKey, error) {
+	raw, err := generateAPIKey()
+	if err != nil {
+		return "", nil, fmt.Errorf("generating key: %w", err)
+	}
+
+	prefix := raw[:8]
+	hash := hashAPIKey(raw)
+
+	result, err := s.db.Exec(
+		"INSERT INTO api_keys (name, key_prefix, key_hash) VALUES (?, ?, ?)",
+		name, prefix, hash,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("storing key: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return "", nil, fmt.Errorf("getting key id: %w", err)
+	}
+
+	key := &APIKey{
+		ID:        id,
+		Name:      name,
+		KeyPrefix: prefix,
+	}
+
+	return raw, key, nil
+}
+
+// List returns all API keys (without the raw key).
+func (s *APIKeyStore) List() ([]APIKey, error) {
+	rows, err := s.db.Query(
+		"SELECT id, name, key_prefix, created_at, last_used_at FROM api_keys ORDER BY created_at DESC",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying keys: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			fmt.Printf("closing rows: %v\n", cerr)
+		}
+	}()
+
+	var keys []APIKey
+	for rows.Next() {
+		var k APIKey
+		if err := rows.Scan(&k.ID, &k.Name, &k.KeyPrefix, &k.CreatedAt, &k.LastUsedAt); err != nil {
+			return nil, fmt.Errorf("scanning key: %w", err)
+		}
+		keys = append(keys, k)
+	}
+
+	return keys, rows.Err()
+}
+
+// Delete removes an API key by ID.
+func (s *APIKeyStore) Delete(id int64) error {
+	result, err := s.db.Exec("DELETE FROM api_keys WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("deleting key: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking affected rows: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("key not found")
+	}
+
+	return nil
+}
+
+// Validate checks a raw API key against stored hashes.
+// Returns true if valid, and updates last_used_at.
+func (s *APIKeyStore) Validate(rawKey string) (bool, error) {
+	hash := hashAPIKey(rawKey)
+
+	result, err := s.db.Exec(
+		"UPDATE api_keys SET last_used_at = ? WHERE key_hash = ?",
+		time.Now(), hash,
+	)
+	if err != nil {
+		return false, fmt.Errorf("validating key: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("checking affected rows: %w", err)
+	}
+
+	return rows > 0, nil
+}
+
+func generateAPIKey() (string, error) {
+	b := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "hf_" + hex.EncodeToString(b), nil
+}
+
+func hashAPIKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/evcraddock/house-finder/internal/db"
+)
+
+func TestAPIKeyCreateAndValidate(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	rawKey, key, err := store.Create("Test Key")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if rawKey == "" {
+		t.Fatal("expected non-empty raw key")
+	}
+	if key.Name != "Test Key" {
+		t.Errorf("name = %q, want %q", key.Name, "Test Key")
+	}
+	if key.KeyPrefix == "" {
+		t.Error("expected non-empty key prefix")
+	}
+	if len(rawKey) < 10 {
+		t.Error("raw key too short")
+	}
+
+	// Validate with correct key
+	valid, err := store.Validate(rawKey)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !valid {
+		t.Error("expected valid key")
+	}
+}
+
+func TestAPIKeyValidateInvalid(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	valid, err := store.Validate("hf_boguskey12345678")
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if valid {
+		t.Error("expected invalid key")
+	}
+}
+
+func TestAPIKeyList(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	if _, _, err := store.Create("Key 1"); err != nil {
+		t.Fatalf("create 1: %v", err)
+	}
+	if _, _, err := store.Create("Key 2"); err != nil {
+		t.Fatalf("create 2: %v", err)
+	}
+
+	keys, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("got %d keys, want 2", len(keys))
+	}
+}
+
+func TestAPIKeyDelete(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	rawKey, key, err := store.Create("To Delete")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := store.Delete(key.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// Should no longer validate
+	valid, err := store.Validate(rawKey)
+	if err != nil {
+		t.Fatalf("validate after delete: %v", err)
+	}
+	if valid {
+		t.Error("expected invalid after delete")
+	}
+
+	// List should be empty
+	keys, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("got %d keys, want 0", len(keys))
+	}
+}
+
+func TestAPIKeyDeleteNotFound(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	if err := store.Delete(999); err == nil {
+		t.Fatal("expected error deleting nonexistent key")
+	}
+}
+
+func TestAPIKeyUpdatesLastUsed(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	rawKey, _, err := store.Create("Usage Key")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Before validation, last_used_at should be nil
+	keys, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if keys[0].LastUsedAt != nil {
+		t.Error("expected nil last_used_at before first use")
+	}
+
+	// Validate to update last_used_at
+	if _, err := store.Validate(rawKey); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	keys, err = store.List()
+	if err != nil {
+		t.Fatalf("list after use: %v", err)
+	}
+	if keys[0].LastUsedAt == nil {
+		t.Error("expected non-nil last_used_at after use")
+	}
+}
+
+func TestAPIKeyPrefix(t *testing.T) {
+	store := testAPIKeyStore(t)
+
+	rawKey, key, err := store.Create("Prefix Key")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Key should start with "hf_" and prefix should be first 8 chars
+	if rawKey[:3] != "hf_" {
+		t.Errorf("raw key should start with hf_, got %q", rawKey[:3])
+	}
+	if key.KeyPrefix != rawKey[:8] {
+		t.Errorf("prefix = %q, want %q", key.KeyPrefix, rawKey[:8])
+	}
+}
+
+func testAPIKeyStore(t *testing.T) *APIKeyStore {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := d.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+	return NewAPIKeyStore(d)
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,10 +3,13 @@ package auth
 import (
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 )
 
-// RequireAuth is middleware that redirects unauthenticated requests to the login page.
+// RequireAuth is middleware that redirects unauthenticated web requests to the login page.
 // It skips auth for public paths (login, static assets, auth endpoints).
+// API paths (/api/...) are handled separately by RequireAPIKey.
 func RequireAuth(sessions *SessionStore, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isPublicPath(r.URL.Path) {
@@ -14,8 +17,103 @@ func RequireAuth(sessions *SessionStore, next http.Handler) http.Handler {
 			return
 		}
 
+		// API paths skip session auth — they use RequireAPIKey instead
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		if _, err := sessions.Validate(r); err != nil {
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// rateLimiter tracks failed API key attempts per IP.
+type rateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string][]time.Time
+}
+
+var apiKeyLimiter = &rateLimiter{
+	attempts: make(map[string][]time.Time),
+}
+
+const (
+	rateLimitWindow  = 1 * time.Minute
+	rateLimitMaxFail = 10
+)
+
+// recordFailure records a failed attempt and returns true if rate limited.
+func (rl *rateLimiter) recordFailure(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-rateLimitWindow)
+
+	// Prune old entries
+	valid := rl.attempts[ip][:0]
+	for _, t := range rl.attempts[ip] {
+		if t.After(cutoff) {
+			valid = append(valid, t)
+		}
+	}
+
+	valid = append(valid, now)
+	rl.attempts[ip] = valid
+
+	return len(valid) > rateLimitMaxFail
+}
+
+// RequireAPIKey is middleware that validates Bearer token auth for /api/ routes.
+// Non-API routes pass through untouched. API key management paths (/api/keys)
+// require session auth instead of bearer tokens.
+// Returns 401 for missing/invalid keys, 429 for rate-limited IPs.
+func RequireAPIKey(apiKeys *APIKeyStore, sessions *SessionStore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only intercept /api/ paths
+		if !strings.HasPrefix(r.URL.Path, "/api/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// API key management endpoints require session auth (web UI), not bearer tokens
+		if isAPIKeyManagementPath(r.URL.Path) {
+			if _, err := sessions.Validate(r); err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ip := r.RemoteAddr
+
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+			http.Error(w, "Authorization required", http.StatusUnauthorized)
+			return
+		}
+
+		key := strings.TrimPrefix(authHeader, "Bearer ")
+
+		// Check rate limit before validating
+		if apiKeyLimiter.recordFailure(ip) {
+			http.Error(w, "Too many requests", http.StatusTooManyRequests)
+			return
+		}
+
+		valid, err := apiKeys.Validate(key)
+		if err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
+		if !valid {
+			http.Error(w, "Invalid API key", http.StatusUnauthorized)
 			return
 		}
 
@@ -35,4 +133,8 @@ func isPublicPath(path string) bool {
 		return true
 	}
 	return false
+}
+
+func isAPIKeyManagementPath(path string) bool {
+	return path == "/api/keys" || strings.HasPrefix(path, "/api/keys/")
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -123,6 +123,11 @@ func TestMigrations(t *testing.T) {
 			table: "passkey_credentials",
 			cols:  []string{"id", "email", "name", "credential_json", "created_at"},
 		},
+		{
+			name:  "api_keys table exists",
+			table: "api_keys",
+			cols:  []string{"id", "name", "key_prefix", "key_hash", "created_at", "last_used_at"},
+		},
 	}
 
 	d := openTestDB(t)

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -53,6 +53,14 @@ var migrations = []string{
 		credential_json TEXT    NOT NULL,
 		created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`,
+	`CREATE TABLE IF NOT EXISTS api_keys (
+		id           INTEGER  PRIMARY KEY AUTOINCREMENT,
+		name         TEXT     NOT NULL,
+		key_prefix   TEXT     NOT NULL,
+		key_hash     TEXT     NOT NULL UNIQUE,
+		created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+		last_used_at DATETIME
+	)`,
 }
 
 // migrate runs all migrations in order.

--- a/internal/web/apikey_handlers.go
+++ b/internal/web/apikey_handlers.go
@@ -1,0 +1,158 @@
+package web
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/evcraddock/house-finder/internal/auth"
+)
+
+// apikeyHandlers holds API key management HTTP handlers.
+type apikeyHandlers struct {
+	apiKeys *auth.APIKeyStore
+}
+
+type apiKeyResponse struct {
+	ID         int64   `json:"id"`
+	Name       string  `json:"name"`
+	KeyPrefix  string  `json:"key_prefix"`
+	CreatedAt  string  `json:"created_at"`
+	LastUsedAt *string `json:"last_used_at,omitempty"`
+}
+
+type apiKeyCreateResponse struct {
+	Key            string         `json:"key"` // raw key, shown once
+	APIKeyResponse apiKeyResponse `json:"api_key"`
+}
+
+// handleCreateKey generates a new API key.
+func (h *apikeyHandlers) handleCreateKey(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		name = "API Key"
+	}
+
+	rawKey, key, err := h.apiKeys.Create(name)
+	if err != nil {
+		log.Printf("Error creating API key: %v", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := apiKeyCreateResponse{
+		Key: rawKey,
+		APIKeyResponse: apiKeyResponse{
+			ID:        key.ID,
+			Name:      key.Name,
+			KeyPrefix: key.KeyPrefix,
+			CreatedAt: key.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("Error encoding response: %v", err)
+	}
+}
+
+// handleListKeys returns all API keys (without raw keys).
+func (h *apikeyHandlers) handleListKeys(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	keys, err := h.apiKeys.List()
+	if err != nil {
+		log.Printf("Error listing API keys: %v", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]apiKeyResponse, len(keys))
+	for i, k := range keys {
+		resp[i] = apiKeyResponse{
+			ID:        k.ID,
+			Name:      k.Name,
+			KeyPrefix: k.KeyPrefix,
+			CreatedAt: k.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		}
+		if k.LastUsedAt != nil {
+			s := k.LastUsedAt.Format("2006-01-02T15:04:05Z")
+			resp[i].LastUsedAt = &s
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("Error encoding response: %v", err)
+	}
+}
+
+// handleDeleteKey revokes an API key.
+func (h *apikeyHandlers) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract ID from /api/keys/{id}
+	idStr := strings.TrimPrefix(r.URL.Path, "/api/keys/")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid key ID", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.apiKeys.Delete(id); err != nil {
+		log.Printf("Error deleting API key: %v", err)
+		http.Error(w, "Key not found", http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleAPIKeysRoute routes /api/keys and /api/keys/{id}.
+func (h *apikeyHandlers) handleAPIKeysRoute(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/keys")
+
+	// /api/keys (no trailing path)
+	if path == "" || path == "/" {
+		switch r.Method {
+		case http.MethodGet:
+			h.handleListKeys(w, r)
+		case http.MethodPost:
+			h.handleCreateKey(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
+	// /api/keys/{id}
+	if r.Method == http.MethodDelete {
+		h.handleDeleteKey(w, r)
+		return
+	}
+
+	http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+}

--- a/internal/web/apikey_handlers_test.go
+++ b/internal/web/apikey_handlers_test.go
@@ -1,0 +1,160 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evcraddock/house-finder/internal/auth"
+)
+
+func TestCreateAPIKey(t *testing.T) {
+	srv, d := testServerWithDBAndAuth(t, "admin@example.com")
+	cookie := createTestSession(t, d, "admin@example.com")
+
+	body := `{"name":"Test CLI"}`
+	r := httptest.NewRequest("POST", "/api/keys", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	var resp apiKeyCreateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Key == "" {
+		t.Error("expected raw key in response")
+	}
+	if resp.APIKeyResponse.Name != "Test CLI" {
+		t.Errorf("name = %q, want %q", resp.APIKeyResponse.Name, "Test CLI")
+	}
+}
+
+func TestListAPIKeys(t *testing.T) {
+	srv, d := testServerWithDBAndAuth(t, "admin@example.com")
+	cookie := createTestSession(t, d, "admin@example.com")
+
+	// Create a key first
+	store := auth.NewAPIKeyStore(d)
+	if _, _, err := store.Create("Key 1"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	r := httptest.NewRequest("GET", "/api/keys", nil)
+	r.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var keys []apiKeyResponse
+	if err := json.NewDecoder(w.Body).Decode(&keys); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("got %d keys, want 1", len(keys))
+	}
+	if keys[0].Name != "Key 1" {
+		t.Errorf("name = %q, want %q", keys[0].Name, "Key 1")
+	}
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	srv, d := testServerWithDBAndAuth(t, "admin@example.com")
+	cookie := createTestSession(t, d, "admin@example.com")
+
+	store := auth.NewAPIKeyStore(d)
+	_, key, err := store.Create("To Revoke")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	r := httptest.NewRequest("DELETE", fmt.Sprintf("/api/keys/%d", key.ID), nil)
+	r.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+
+	// Verify deleted
+	keys, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("got %d keys after delete, want 0", len(keys))
+	}
+}
+
+func TestAPIKeysRequireSession(t *testing.T) {
+	srv := testServerWithAuth(t, "admin@example.com")
+
+	// No session cookie — should get 401
+	r := httptest.NewRequest("GET", "/api/keys", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBearerTokenAuth(t *testing.T) {
+	srv, d := testServerWithDBAndAuth(t, "admin@example.com")
+
+	// Create an API key
+	store := auth.NewAPIKeyStore(d)
+	rawKey, _, err := store.Create("CLI Key")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Access a future API endpoint with bearer token (use a non-management /api/ path)
+	// For now, test that an unknown /api/ path with valid bearer returns 404 (not 401)
+	r := httptest.NewRequest("GET", "/api/properties", nil)
+	r.Header.Set("Authorization", "Bearer "+rawKey)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	// Should not be 401 — bearer auth passed, handler just doesn't exist yet
+	if w.Code == http.StatusUnauthorized {
+		t.Error("expected bearer auth to pass, got 401")
+	}
+}
+
+func TestBearerTokenInvalid(t *testing.T) {
+	srv := testServerWithAuth(t, "admin@example.com")
+
+	r := httptest.NewRequest("GET", "/api/properties", nil)
+	r.Header.Set("Authorization", "Bearer hf_invalidkey")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBearerTokenMissing(t *testing.T) {
+	srv := testServerWithAuth(t, "admin@example.com")
+
+	r := httptest.NewRequest("GET", "/api/properties", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -240,6 +240,15 @@ header { display: flex; justify-content: space-between; align-items: center; }
 [data-theme="dark"] .passkey-success { color: #4ade80; }
 [data-theme="dark"] .passkey-error { color: #f87171; }
 
+/* API key reveal */
+.apikey-reveal { margin-top: 1rem; padding: 1rem; background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 6px; }
+.apikey-warning { color: #b45309; font-weight: 600; margin-bottom: 0.5rem; font-size: 0.9rem; }
+.apikey-value { display: block; padding: 0.5rem; background: #f9fafb; border: 1px solid #d1d5db; border-radius: 4px; font-size: 0.85rem; word-break: break-all; margin-bottom: 0.5rem; }
+.apikey-create { margin-top: 1rem; }
+[data-theme="dark"] .apikey-reveal { background: #064e3b; border-color: #065f46; }
+[data-theme="dark"] .apikey-warning { color: #fbbf24; }
+[data-theme="dark"] .apikey-value { background: #1f2937; border-color: #4b5563; color: #e5e7eb; }
+
 /* Login divider */
 .login-section { margin-bottom: 0.5rem; }
 .login-divider { display: flex; align-items: center; margin: 1rem 0; color: #9ca3af; font-size: 0.9rem; }

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -22,6 +22,27 @@
     </header>
     <main>
         <a href="/" class="back-link">← Properties</a>
+
+        <!-- API Keys -->
+        <div class="card">
+            <h2>API Keys</h2>
+            <p class="settings-info">API keys let the CLI and other tools access House Finder programmatically.</p>
+
+            <div id="apikey-list"></div>
+
+            <div class="apikey-create">
+                <input type="text" id="apikey-name" placeholder="Key name (e.g. laptop)" class="login-input" style="max-width:300px;display:inline-block;margin-right:0.5rem;">
+                <button class="btn" onclick="createAPIKey()">Generate Key</button>
+            </div>
+            <div id="apikey-status" class="passkey-status"></div>
+            <div id="apikey-reveal" class="apikey-reveal" style="display:none;">
+                <p class="apikey-warning">⚠️ Copy this key now — it won't be shown again.</p>
+                <code id="apikey-value" class="apikey-value"></code>
+                <button class="btn btn-sm" onclick="copyAPIKey()">Copy</button>
+            </div>
+        </div>
+
+        <!-- Passkeys -->
         <div class="card">
             <h2>Passkeys</h2>
             <p class="settings-info">Passkeys let you sign in with your fingerprint, face, or device PIN instead of a magic link email.</p>
@@ -65,6 +86,97 @@
     </main>
 
     <script>
+    // === API Keys ===
+
+    async function loadAPIKeys() {
+        const container = document.getElementById('apikey-list');
+        try {
+            const resp = await fetch('/api/keys');
+            if (!resp.ok) throw new Error('Failed to load keys');
+            const keys = await resp.json();
+
+            if (!keys || keys.length === 0) {
+                container.innerHTML = '<p class="empty">No API keys yet.</p>';
+                return;
+            }
+
+            let html = '<table class="passkey-table"><thead><tr><th>Name</th><th>Prefix</th><th>Created</th><th>Last Used</th><th></th></tr></thead><tbody>';
+            for (const k of keys) {
+                const created = new Date(k.created_at).toLocaleDateString();
+                const lastUsed = k.last_used_at ? new Date(k.last_used_at).toLocaleDateString() : '—';
+                html += '<tr>';
+                html += '<td>' + escapeHtml(k.name) + '</td>';
+                html += '<td><code>' + escapeHtml(k.key_prefix) + '…</code></td>';
+                html += '<td>' + created + '</td>';
+                html += '<td>' + lastUsed + '</td>';
+                html += '<td><button class="btn btn-danger btn-sm" onclick="deleteAPIKey(' + k.id + ')">Revoke</button></td>';
+                html += '</tr>';
+            }
+            html += '</tbody></table>';
+            container.innerHTML = html;
+        } catch (err) {
+            container.innerHTML = '<p class="passkey-error">Failed to load API keys.</p>';
+        }
+    }
+
+    async function createAPIKey() {
+        const nameInput = document.getElementById('apikey-name');
+        const statusEl = document.getElementById('apikey-status');
+        const revealEl = document.getElementById('apikey-reveal');
+        const valueEl = document.getElementById('apikey-value');
+        const name = nameInput.value.trim() || 'API Key';
+
+        try {
+            const resp = await fetch('/api/keys', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({name: name})
+            });
+            if (!resp.ok) throw new Error('Failed to create key');
+            const data = await resp.json();
+
+            valueEl.textContent = data.key;
+            revealEl.style.display = 'block';
+            statusEl.textContent = '';
+            nameInput.value = '';
+            loadAPIKeys();
+        } catch (err) {
+            statusEl.textContent = '✗ ' + err.message;
+            statusEl.className = 'passkey-status passkey-error';
+        }
+    }
+
+    async function deleteAPIKey(id) {
+        if (!confirm('Revoke this API key? Any tools using it will stop working.')) return;
+        try {
+            const resp = await fetch('/api/keys/' + id, {method: 'DELETE'});
+            if (!resp.ok) throw new Error('Failed to revoke key');
+            loadAPIKeys();
+        } catch (err) {
+            alert('Error: ' + err.message);
+        }
+    }
+
+    function copyAPIKey() {
+        const value = document.getElementById('apikey-value').textContent;
+        navigator.clipboard.writeText(value).then(() => {
+            const btn = event.target;
+            btn.textContent = 'Copied!';
+            setTimeout(() => btn.textContent = 'Copy', 2000);
+        });
+    }
+
+    function escapeHtml(s) {
+        const d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    // Load API keys on page load
+    loadAPIKeys();
+
+    // === Passkeys ===
+
     async function registerPasskey() {
         const statusEl = document.getElementById('passkey-status');
         const nameInput = document.getElementById('passkey-name');
@@ -72,26 +184,21 @@
         statusEl.textContent = 'Starting registration...';
 
         try {
-            // 1. Get registration options from server
             const beginResp = await fetch('/passkey/register/begin');
             if (!beginResp.ok) throw new Error('Failed to start registration');
             const options = await beginResp.json();
 
-            // 2. Decode base64url fields for WebAuthn API
             options.publicKey.challenge = base64urlToBuffer(options.publicKey.challenge);
             options.publicKey.user.id = base64urlToBuffer(options.publicKey.user.id);
             if (options.publicKey.excludeCredentials) {
                 options.publicKey.excludeCredentials = options.publicKey.excludeCredentials.map(c => ({
-                    ...c,
-                    id: base64urlToBuffer(c.id)
+                    ...c, id: base64urlToBuffer(c.id)
                 }));
             }
 
-            // 3. Create credential via browser WebAuthn API
             statusEl.textContent = 'Waiting for authenticator...';
             const credential = await navigator.credentials.create(options);
 
-            // 4. Encode response for server
             const attestationResponse = {
                 id: credential.id,
                 rawId: bufferToBase64url(credential.rawId),
@@ -101,19 +208,15 @@
                     clientDataJSON: bufferToBase64url(credential.response.clientDataJSON)
                 }
             };
-
-            // Include transports if available
             if (credential.response.getTransports) {
                 attestationResponse.response.transports = credential.response.getTransports();
             }
 
-            // 5. Send to server
             const finishResp = await fetch('/passkey/register/finish?name=' + encodeURIComponent(name), {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify(attestationResponse)
             });
-
             if (!finishResp.ok) throw new Error('Registration failed');
 
             statusEl.textContent = '✓ Passkey registered!';


### PR DESCRIPTION
## Summary

Add API key management and bearer token authentication. PR 1 of 2 for task #1649.

## How It Works

### API Key Management (session auth via web UI)
- **POST /api/keys** — Generate new key (returns raw key once, stores sha256 hash)
- **GET /api/keys** — List keys (name, prefix, created, last used)
- **DELETE /api/keys/{id}** — Revoke a key

### Bearer Token Auth (for /api/ endpoints)
- CLI/tools send `Authorization: Bearer hf_...` header
- Middleware validates against stored hashes, updates last_used_at
- Rate limited: 10 failed attempts per minute per IP

### Auth Layering
```
Request → RequireAPIKey → RequireAuth → Handler
           │                  │
           ├─ /api/keys/*     ├─ /login, /static, etc → pass through
           │  → session auth  ├─ /api/* → pass through (handled above)
           │                  └─ everything else → session required
           ├─ /api/* (other)
           │  → bearer token required
           └─ non-/api/
              → pass through
```

## Changes

- **internal/auth/apikey.go** — APIKeyStore (create, list, delete, validate), hashing
- **internal/auth/middleware.go** — RequireAPIKey middleware, rate limiter
- **internal/web/apikey_handlers.go** — REST endpoints for key management
- **internal/web/server.go** — Wire API key routes and middleware
- **internal/web/templates/settings.html** — API Keys section (generate, list, revoke, copy)
- **internal/web/static/style.css** — API key reveal styles
- **internal/db/migrations.go** — api_keys table

## Key Design Decisions

- Keys prefixed with `hf_` for easy identification
- First 8 chars stored as `key_prefix` for display (`hf_b9ed2...`)
- Raw key shown once on creation, never stored
- SHA256 hash comparison (not bcrypt) for low-latency API auth
- Rate limiting is in-memory (single process, acceptable for single-admin app)

## Tests

- APIKeyStore: create+validate, invalid key, list, delete, not found, last_used update, prefix format
- Handlers: create, list, delete, session required for management, bearer valid/invalid/missing
- DB: api_keys table schema
- E2E: Playwright test of settings page key creation + bearer token rejection

## Still To Come (PR 2)

- CLI config file support (`~/.config/hf/config.yaml`)
- CLI sends Bearer token with API requests
- `hf login` command to store API key

Task: #1649