### PR TITLE
feat: add property form on front page

### DIFF
--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -24,8 +24,24 @@ func TestHandleListEmpty(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
 	}
-	if !strings.Contains(w.Body.String(), "No properties yet") {
+	if !strings.Contains(w.Body.String(), "No properties in this tab") {
 		t.Error("expected empty state message")
+	}
+}
+
+func TestHandleListHasAddForm(t *testing.T) {
+	srv := testServer(t)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "add-property-form") {
+		t.Error("expected add property form")
+	}
+	if !strings.Contains(body, "Enter address or MLS ID") {
+		t.Error("expected address input placeholder")
 	}
 }
 

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -266,6 +266,17 @@ header { display: flex; justify-content: space-between; align-items: center; }
 [data-theme="dark"] .login-divider::before, [data-theme="dark"] .login-divider::after { background: #4b5563; }
 [data-theme="dark"] .login-divider { color: #6b7280; }
 
+/* Add property form */
+.add-property-form { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin-bottom: 1.5rem; }
+.add-property-form input[type="text"] { flex: 1; min-width: 200px; padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 6px; font-size: 0.95rem; background: #fff; color: #1f2937; }
+.add-property-form button { padding: 0.5rem 1.2rem; background: #3b82f6; color: #fff; border: none; border-radius: 6px; font-size: 0.95rem; cursor: pointer; white-space: nowrap; }
+.add-property-form button:hover { background: #2563eb; }
+.add-property-form button:disabled { background: #93c5fd; cursor: wait; }
+.add-status { width: 100%; font-size: 0.85rem; min-height: 1.2em; }
+.add-status.error { color: #ef4444; }
+[data-theme="dark"] .add-property-form input[type="text"] { background: #1e293b; color: #e5e7eb; border-color: #374151; }
+[data-theme="dark"] .add-property-form button:disabled { background: #1e40af; }
+
 /* Tabs */
 .tabs { display: flex; gap: 0; margin-bottom: 1.5rem; border-bottom: 2px solid #e5e7eb; }
 .tab { padding: 0.6rem 1.2rem; text-decoration: none; color: #6b7280; font-weight: 500; border-bottom: 2px solid transparent; margin-bottom: -2px; }

--- a/internal/web/templates/list.html
+++ b/internal/web/templates/list.html
@@ -27,6 +27,12 @@
             <a href="/?tab=not-visited" class="tab{{if eq .Tab "not-visited"}} active{{end}}">Not Visited ({{.NotVisitedCnt}})</a>
             <a href="/?tab=visited" class="tab{{if eq .Tab "visited"}} active{{end}}">Visited ({{.VisitedCnt}})</a>
         </div>
+        <form id="add-property-form" class="add-property-form" onsubmit="return addProperty(event)">
+            <input type="text" id="add-address" placeholder="Enter address or MLS ID" required autocomplete="off">
+            <button type="submit" id="add-btn">Add</button>
+            <div id="add-status" class="add-status"></div>
+        </form>
+
         {{if .Properties}}
         <table>
             <thead>
@@ -53,8 +59,53 @@
             </tbody>
         </table>
         {{else}}
-        <div class="empty">No properties yet. Use <code>hf add "address"</code> to add one.</div>
+        <div class="empty">No properties in this tab.</div>
         {{end}}
     </main>
+    <script>
+    function addProperty(e) {
+        e.preventDefault();
+        var input = document.getElementById('add-address');
+        var btn = document.getElementById('add-btn');
+        var status = document.getElementById('add-status');
+        var address = input.value.trim();
+        if (!address) return false;
+
+        btn.disabled = true;
+        btn.textContent = 'Looking up…';
+        status.textContent = '';
+        status.className = 'add-status';
+
+        fetch('/api/properties', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({address: address})
+        })
+        .then(function(resp) {
+            return resp.json().then(function(data) {
+                return {ok: resp.ok, data: data};
+            });
+        })
+        .then(function(result) {
+            btn.disabled = false;
+            btn.textContent = 'Add';
+            if (!result.ok) {
+                status.textContent = result.data.error || 'Failed to add property';
+                status.className = 'add-status error';
+                return;
+            }
+            input.value = '';
+            window.location.href = '/?tab=not-visited';
+        })
+        .catch(function(err) {
+            btn.disabled = false;
+            btn.textContent = 'Add';
+            status.textContent = 'Network error: ' + err.message;
+            status.className = 'add-status error';
+        });
+
+        return false;
+    }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Task #1658 — Add property form on front page

### Changes

- **Inline form** above the property table with address/MLS ID input and Add button
- **Loading state**: button shows "Looking up…" and disables while API call is in progress
- **Error handling**: inline error message on failure (red text below form)
- **On success**: reloads the Not Visited tab so the new property appears
- **Empty state**: updated message from "Use hf add" to "No properties in this tab"
- **CSS**: form styles for light and dark themes
- **Tests**: form presence test, updated empty state test