### PR TITLE
feat: cross-platform install script and macOS CI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,40 +11,39 @@ permissions:
 
 jobs:
   build-binaries:
-    name: Build binaries
-    runs-on: ubuntu-latest
+    name: Build binaries (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - goos: linux
             goarch: amd64
+            os: ubuntu-latest
             cc: gcc
           - goos: linux
             goarch: arm64
+            os: ubuntu-latest
             cc: aarch64-linux-gnu-gcc
           - goos: darwin
             goarch: amd64
-            cc: o64-clang
-            skip: true  # Cross-compiling CGO for macOS on Linux is complex
+            os: macos-13
+            cc: clang
           - goos: darwin
             goarch: arm64
-            cc: o64-clang
-            skip: true
+            os: macos-latest
+            cc: clang
     steps:
       - uses: actions/checkout@v4
-        if: ${{ !matrix.skip }}
 
       - uses: actions/setup-go@v5
-        if: ${{ !matrix.skip }}
         with:
           go-version-file: go.mod
 
       - name: Install cross-compilation tools
-        if: ${{ !matrix.skip && matrix.goarch == 'arm64' && matrix.goos == 'linux' }}
+        if: ${{ matrix.goarch == 'arm64' && matrix.goos == 'linux' }}
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Build
-        if: ${{ !matrix.skip }}
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -56,7 +55,6 @@ jobs:
           go build -ldflags "${LDFLAGS}" -o hf-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/hf
 
       - name: Upload artifact
-        if: ${{ !matrix.skip }}
         uses: actions/upload-artifact@v4
         with:
           name: hf-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/README.md
+++ b/README.md
@@ -4,13 +4,29 @@
 
 A tool to find and track houses for sale. Add properties by address, rate them, leave comments, and browse via CLI or web UI.
 
-## Prerequisites
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/evcraddock/house-finder/main/install.sh | sh
+```
+
+Or specify a version and install directory:
+
+```bash
+VERSION=v0.1.1 INSTALL_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/evcraddock/house-finder/main/install.sh | sh
+```
+
+Pre-built binaries are available for Linux (amd64, arm64) and macOS (amd64, arm64).
+
+## Development
+
+### Prerequisites
 
 - Go 1.21+
 - golangci-lint
 - A [RapidAPI](https://rapidapi.com/) key for the us-real-estate-listings API
 
-## Setup
+### Setup
 
 ```bash
 go mod download
@@ -18,7 +34,7 @@ cp .env.example .env
 # Edit .env and add your RAPIDAPI_KEY, HF_ADMIN_EMAIL, etc.
 ```
 
-## Build
+### Build
 
 ```bash
 make build

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env sh
+#
+# Install the hf CLI from GitHub releases.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/evcraddock/house-finder/main/install.sh | sh
+#
+# Options (via env vars):
+#   INSTALL_DIR  — where to install (default: /usr/local/bin, or ~/.local/bin if no write access)
+#   VERSION      — specific version to install (default: latest)
+#
+set -e
+
+REPO="evcraddock/house-finder"
+BINARY="hf"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+  linux)  OS="linux" ;;
+  darwin) OS="darwin" ;;
+  *)
+    echo "Error: unsupported OS: $OS" >&2
+    echo "Supported: linux, darwin (macOS)" >&2
+    exit 1
+    ;;
+esac
+
+# Detect arch
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64)  ARCH="amd64" ;;
+  aarch64|arm64)  ARCH="arm64" ;;
+  *)
+    echo "Error: unsupported architecture: $ARCH" >&2
+    echo "Supported: amd64 (x86_64), arm64 (aarch64)" >&2
+    exit 1
+    ;;
+esac
+
+# Determine install directory
+if [ -n "$INSTALL_DIR" ]; then
+  DIR="$INSTALL_DIR"
+elif [ -w /usr/local/bin ]; then
+  DIR="/usr/local/bin"
+else
+  DIR="$HOME/.local/bin"
+  mkdir -p "$DIR"
+fi
+
+# Determine version
+if [ -n "$VERSION" ]; then
+  TAG="$VERSION"
+else
+  echo "Finding latest release..."
+  TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+  if [ -z "$TAG" ]; then
+    echo "Error: could not determine latest version" >&2
+    exit 1
+  fi
+fi
+
+ARTIFACT="${BINARY}-${OS}-${ARCH}"
+URL="https://github.com/$REPO/releases/download/${TAG}/${ARTIFACT}"
+
+echo "Installing $BINARY $TAG ($OS/$ARCH) to $DIR..."
+
+# Download
+TMP=$(mktemp)
+if ! curl -fsSL -o "$TMP" "$URL"; then
+  echo "Error: download failed — $URL" >&2
+  echo "Check that $TAG has a binary for $OS/$ARCH" >&2
+  rm -f "$TMP"
+  exit 1
+fi
+
+# Install
+chmod +x "$TMP"
+mv "$TMP" "$DIR/$BINARY"
+
+echo "Installed $BINARY to $DIR/$BINARY"
+
+# Check if in PATH
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$DIR"; then
+  echo ""
+  echo "Note: $DIR is not in your PATH. Add it:"
+  echo "  export PATH=\"$DIR:\$PATH\""
+fi
+
+echo ""
+"$DIR/$BINARY" version 2>/dev/null || true


### PR DESCRIPTION
## Task #1692 — Cross-platform install script for hf CLI

### Changes

**Release workflow:**
- macOS builds now run on native runners (`macos-latest` for arm64, `macos-13` for amd64) — no more cross-compilation skip
- All 4 platforms build: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64

**Install script (`install.sh`):**
- Detects OS (linux/darwin) and arch (amd64/arm64)
- Downloads correct binary from latest GitHub release
- Installs to `/usr/local/bin` or `~/.local/bin`
- Configurable via `VERSION` and `INSTALL_DIR` env vars
- Warns if install dir not in PATH

**Usage:**
```bash
curl -fsSL https://raw.githubusercontent.com/evcraddock/house-finder/main/install.sh | sh
```

**README** updated with install instructions.