### PR TITLE
feat: simplify header to single settings icon

### DIFF
--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -230,6 +230,28 @@ td.rating { font-size: 1.1rem; }
 .nav-link.active { font-weight: 600; }
 header { display: flex; justify-content: space-between; align-items: center; }
 
+/* Settings icon in header */
+.settings-icon {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 44px; height: 44px; border-radius: 50%;
+    color: #6b7280; transition: color 0.15s, background 0.15s;
+}
+.settings-icon:hover { color: #2563eb; background: rgba(37,99,235,0.08); }
+.settings-icon.active { color: #2563eb; }
+[data-theme="dark"] .settings-icon { color: #9ca3af; }
+[data-theme="dark"] .settings-icon:hover { color: #60a5fa; background: rgba(96,165,250,0.1); }
+[data-theme="dark"] .settings-icon.active { color: #60a5fa; }
+
+/* Theme toggle on settings page */
+.theme-setting { display: flex; align-items: center; justify-content: space-between; }
+.theme-toggle-btn {
+    padding: 0.4rem 1rem; border: 1px solid #d1d5db; border-radius: 6px;
+    background: #fff; cursor: pointer; font-size: 0.9rem; min-height: 44px;
+}
+.theme-toggle-btn:hover { border-color: #2563eb; }
+[data-theme="dark"] .theme-toggle-btn { background: #1f2937; border-color: #4b5563; color: #e5e7eb; }
+[data-theme="dark"] .theme-toggle-btn:hover { border-color: #60a5fa; }
+
 /* Settings page */
 .settings-info { color: #6b7280; margin-bottom: 1rem; font-size: 0.95rem; }
 .passkey-table { margin-bottom: 1rem; }
@@ -337,12 +359,9 @@ tr.rating-1 { background-color: rgba(239, 68, 68, 0.25); }
 @media (max-width: 600px) {
     body { padding: 0.5rem; }
 
-    /* Header: stack vertically */
-    header { flex-wrap: wrap; gap: 0.5rem; padding: 0.75rem 0; margin-bottom: 1rem; }
-    header h1 { font-size: 1.25rem; width: 100%; }
-    .header-nav { gap: 0.75rem; }
-    .nav-link { font-size: 0.95rem; min-height: 44px; display: inline-flex; align-items: center; }
-    .theme-toggle { min-width: 44px; min-height: 44px; }
+    /* Header */
+    header { padding: 0.75rem 0; margin-bottom: 1rem; }
+    header h1 { font-size: 1.25rem; }
 
     /* Tabs: tappable */
     .tab { padding: 0.75rem 1rem; min-height: 44px; font-size: 0.9rem; }

--- a/internal/web/templates/admin_users.html
+++ b/internal/web/templates/admin_users.html
@@ -12,14 +12,7 @@
 <body>
     <header>
         <h1><a href="/">House Finder</a></h1>
-        <nav class="header-nav">
-            <a href="/admin/users" class="nav-link active">Users</a>
-            <a href="/settings" class="nav-link">Settings</a>
-            <a href="/auth/logout" class="nav-link">Logout</a>
-        </nav>
-        <button class="theme-toggle" onclick="var d=document.documentElement;var t=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',t);localStorage.setItem('theme',t);this.textContent=t==='dark'?'☀️':'🌙';" id="theme-btn">
-            <script>document.write(localStorage.getItem('theme')==='dark'?'☀️':'🌙')</script>
-        </button>
+        <a href="/settings" class="settings-icon" aria-label="Settings"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></a>
     </header>
     <main>
         <a href="/" class="back-link">← Properties</a>

--- a/internal/web/templates/detail.html
+++ b/internal/web/templates/detail.html
@@ -13,14 +13,7 @@
 <body>
     <header>
         <h1><a href="/">House Finder</a></h1>
-        <nav class="header-nav">
-            {{if .IsAdmin}}<a href="/admin/users" class="nav-link">Users</a>{{end}}
-            <a href="/settings" class="nav-link">Settings</a>
-            <a href="/auth/logout" class="nav-link">Logout</a>
-        </nav>
-        <button class="theme-toggle" onclick="var d=document.documentElement;var t=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',t);localStorage.setItem('theme',t);this.textContent=t==='dark'?'☀️':'🌙';" id="theme-btn">
-            <script>document.write(localStorage.getItem('theme')==='dark'?'☀️':'🌙')</script>
-        </button>
+        <a href="/settings" class="settings-icon" aria-label="Settings"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></a>
     </header>
     <main>
         <a href="/" class="back-link">← All Properties</a>

--- a/internal/web/templates/list.html
+++ b/internal/web/templates/list.html
@@ -13,14 +13,7 @@
 <body>
     <header>
         <h1><a href="/">House Finder</a></h1>
-        <nav class="header-nav">
-            {{if .IsAdmin}}<a href="/admin/users" class="nav-link">Users</a>{{end}}
-            <a href="/settings" class="nav-link">Settings</a>
-            <a href="/auth/logout" class="nav-link">Logout</a>
-        </nav>
-        <button class="theme-toggle" onclick="var d=document.documentElement;var t=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',t);localStorage.setItem('theme',t);this.textContent=t==='dark'?'☀️':'🌙';" id="theme-btn">
-            <script>document.write(localStorage.getItem('theme')==='dark'?'☀️':'🌙')</script>
-        </button>
+        <a href="/settings" class="settings-icon" aria-label="Settings"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></a>
     </header>
     <main>
         <div class="tabs">

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -12,14 +12,7 @@
 <body>
     <header>
         <h1><a href="/">House Finder</a></h1>
-        <nav class="header-nav">
-            {{if .IsAdmin}}<a href="/admin/users" class="nav-link">Users</a>{{end}}
-            <a href="/settings" class="nav-link active">Settings</a>
-            <a href="/auth/logout" class="nav-link">Logout</a>
-        </nav>
-        <button class="theme-toggle" onclick="var d=document.documentElement;var t=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',t);localStorage.setItem('theme',t);this.textContent=t==='dark'?'☀️':'🌙';" id="theme-btn">
-            <script>document.write(localStorage.getItem('theme')==='dark'?'☀️':'🌙')</script>
-        </button>
+        <a href="/settings" class="settings-icon active" aria-label="Settings"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></a>
     </header>
     <main>
         <a href="/" class="back-link">← Properties</a>
@@ -94,6 +87,22 @@
             <a href="/admin/users" class="btn">Manage Users →</a>
         </div>
         {{end}}
+
+        <!-- Appearance -->
+        <div class="card">
+            <h2>Appearance</h2>
+            <div class="theme-setting">
+                <span>Dark Mode</span>
+                <button class="theme-toggle-btn" onclick="var d=document.documentElement;var t=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',t);localStorage.setItem('theme',t);this.textContent=t==='dark'?'On':'Off';" id="theme-btn">
+                    <script>document.write(localStorage.getItem('theme')==='dark'?'On':'Off')</script>
+                </button>
+            </div>
+        </div>
+
+        <!-- Account -->
+        <div class="card">
+            <a href="/auth/logout" class="btn btn-secondary">Log Out</a>
+        </div>
 
     </main>
 


### PR DESCRIPTION
## Task #1710

### Changes
Replace cluttered header nav (Users, Settings, Logout, dark mode toggle) with a single person icon linking to settings.

**Header** (all pages): Just `House Finder` title + person SVG icon → settings page

**Settings page** (new sections):
- **Appearance**: Dark mode On/Off toggle
- **Account**: Log Out button
- Users link already existed (admin only)

### Files (5 changed, +45 -38)
- `style.css`: Settings icon styles, theme toggle button, removed old header-nav mobile overrides
- `list.html`, `detail.html`, `admin_users.html`: Replaced nav+toggle with single icon
- `settings.html`: Added Appearance + Log Out sections

### Desktop unchanged behavior
Same functionality, just relocated from header to settings page.