### PR TITLE
fix: scope API keys to owning user

### DIFF
--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -64,10 +64,11 @@ func (s *APIKeyStore) Create(name, email string) (string, *APIKey, error) {
 	return raw, key, nil
 }
 
-// List returns all API keys (without the raw key).
-func (s *APIKeyStore) List() ([]APIKey, error) {
+// List returns API keys for the given email (without the raw key).
+func (s *APIKeyStore) List(email string) ([]APIKey, error) {
 	rows, err := s.db.Query(
-		"SELECT id, name, key_prefix, created_at, last_used_at FROM api_keys ORDER BY created_at DESC",
+		"SELECT id, name, key_prefix, created_at, last_used_at FROM api_keys WHERE email = ? ORDER BY created_at DESC",
+		email,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying keys: %w", err)
@@ -90,9 +91,9 @@ func (s *APIKeyStore) List() ([]APIKey, error) {
 	return keys, rows.Err()
 }
 
-// Delete removes an API key by ID.
-func (s *APIKeyStore) Delete(id int64) error {
-	result, err := s.db.Exec("DELETE FROM api_keys WHERE id = ?", id)
+// Delete removes an API key by ID, scoped to the given email.
+func (s *APIKeyStore) Delete(id int64, email string) error {
+	result, err := s.db.Exec("DELETE FROM api_keys WHERE id = ? AND email = ?", id, email)
 	if err != nil {
 		return fmt.Errorf("deleting key: %w", err)
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -104,11 +104,12 @@ func RequireAPIKey(apiKeys *APIKeyStore, sessions *SessionStore, next http.Handl
 
 		// API key management endpoints require session auth (web UI), not bearer tokens
 		if isAPIKeyManagementPath(r.URL.Path) {
-			if _, err := sessions.Validate(r); err != nil {
+			email, err := sessions.Validate(r)
+			if err != nil {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(w, WithUserEmail(r, email))
 			return
 		}
 

--- a/internal/web/apikey_handlers_test.go
+++ b/internal/web/apikey_handlers_test.go
@@ -89,7 +89,7 @@ func TestDeleteAPIKey(t *testing.T) {
 	}
 
 	// Verify deleted
-	keys, err := store.List()
+	keys, err := store.List("admin@example.com")
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -160,7 +160,7 @@ func NewServer(db *sql.DB, authCfg auth.Config, mlsClient ...*mls.Client) (*Serv
 	}
 
 	// API key management routes (session-protected via RequireAPIKey middleware)
-	akh := &apikeyHandlers{apiKeys: apiKeys, sessions: sessions}
+	akh := &apikeyHandlers{apiKeys: apiKeys}
 	mux.HandleFunc("/api/keys", akh.handleAPIKeysRoute)
 	mux.HandleFunc("/api/keys/", akh.handleAPIKeysRoute)
 


### PR DESCRIPTION
## Task #1695

### Bug
API keys were not scoped to the user who created them:
1. `List()` returned ALL keys — every user saw everyone's keys
2. `Delete()` had no ownership check — any user could revoke anyone's key
3. API key management middleware didn't set user context via `WithUserEmail`

### Fix
- `List(email)` — filtered by owner email
- `Delete(id, email)` — requires matching owner email
- `RequireAPIKey` middleware now calls `WithUserEmail` for management paths
- `handleCreateKey` returns 401 if no user context (was silently creating unowned keys)

### Tests
- `TestAPIKeyDeleteWrongOwner` — verifies cross-user deletion fails
- `TestAPIKeyList` — verifies other users see zero keys
- All existing tests updated to pass email param

### Files (6 changed, +66 -24)
- `apikey.go`: `List(email)`, `Delete(id, email)`
- `apikey_test.go`: New ownership tests
- `middleware.go`: `WithUserEmail` in management path
- `apikey_handlers.go`: Use `UserEmailFromContext`, require auth
- `apikey_handlers_test.go`: Updated `List` call
- `server.go`: Removed unused `sessions` from `apikeyHandlers`